### PR TITLE
URI-encode the email address before transmitting it

### DIFF
--- a/Clearpay/Clearpay/view/frontend/web/js/view/payment/method-renderer/clearpaypayovertime.js
+++ b/Clearpay/Clearpay/view/frontend/web/js/view/payment/method-renderer/clearpaypayovertime.js
@@ -138,7 +138,7 @@ define(
                             email = document.getElementById("customer-email").value;
                         }
 
-                        data = data + '&email=' + email;
+                        data = data + '&email=' + encodeURIComponent(email);
 
 
                         $.ajax({


### PR DESCRIPTION
If the email address contains "+" characters, those are currently removed by afterpay. They are not only removed from the afterpay data, but also from the Magento order data. 

This is an example:

I place a test order with email address test+123@example.org. The order is placed, and I find it in Magento admin with the email address test123@example.org.

While the + character is probably rare in day-to-day use of email, it is valid syntax:

> Without quotes, local-parts may consist of any combination of alphabetic characters, digits, or any of the special characters
> 
>       ! # $ % & ' * + - / = ?  ^ _ ` . { | } ~
> 
> period (".") may also appear, but may not be used to start or end the local part, nor may two or more consecutive periods appear.

(see https://tools.ietf.org/html/rfc3696#section-3). This indicates that the same bug could exist with some of the other characters mentioned in the RFC document.

Investigating why this happened it seemed that the client-side code sends a space instead of the "+" character to the server. 

The _post_ data is assembled in `clearpaypayovertime.js`, around line 141. At this stage, the _data_ string contains all the address information, assembled via `var data = $("#co-shipping-form").serialize();`. The `serialize` method takes care of the uri conversion (compare https://api.jquery.com/serialize/). 
Then, in line 141, the email address is added to the url encoded string: `data = data + '&email=' + email;`. Obviously, the email address should be encoded before being added to the encoded string. 

There are two options to do that: `encodeURI` and `encodeURIComponent`. We need the latter one, because we need special characters like "+" encoded.

The suggestion is therefore, to replace

```data = data + '&email=' + email;```
with 
```data = data + '&email=' + encodeURIComponent(email);```


Impact:
Bearing the relevance of data protection in mind, the criticality of this fix seems to be high. In fact, the email address of the customer is changed by the clearpay module. This can potentially lead to 3rd parties receiving order confirmation and invoice emails which were sent to customers. Order confirmations and invoice emails would usually contain personal data.

The same fix is necessary for the afterpay code.

Tests:
I have tested with Magento 2.2.9 and gmail addresses with a "+" character. The fix works.